### PR TITLE
RFC: Modernize the stack

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,15 +1,15 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdk 26
+    compileSdk 34
 
     defaultConfig {
         applicationId "de.rochefort.childmonitor"
         minSdkVersion 21
-        //noinspection ExpiredTargetSdkVersion
-        targetSdkVersion 26
+        targetSdkVersion 34
         versionCode 11
         versionName "1.1"
+        multiDexEnabled true
     }
 
     buildTypes {
@@ -19,9 +19,8 @@ android {
         }
     }
 
-
     dependencies {
-        implementation "com.android.support:support-compat:26.1.0"
+        coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_nio:2.0.4'
     }
     namespace 'de.rochefort.childmonitor'
     lint {
@@ -29,7 +28,14 @@ android {
         warning 'MissingTranslation'
     }
     compileOptions {
+        // Flag to enable support for the new language APIs
+        coreLibraryDesugaringEnabled true
+        // Sets Java compatibility to Java 8
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+}
+
+dependencies {
+    implementation 'androidx.core:core:1.12.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,10 @@
         android:required="true" />
     <uses-permission
         android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
 
     <application
         android:allowBackup="true"
@@ -30,10 +34,12 @@
         <service
             android:name=".ListenService"
             android:enabled="true"
+            android:foregroundServiceType="mediaPlayback"
             android:exported="false"/>
         <service
             android:name=".MonitorService"
             android:enabled="true"
+            android:foregroundServiceType="microphone"
             android:exported="false"/>
 
         <activity

--- a/app/src/main/java/de/rochefort/childmonitor/ListenActivity.java
+++ b/app/src/main/java/de/rochefort/childmonitor/ListenActivity.java
@@ -24,7 +24,7 @@ import android.content.ServiceConnection;
 import android.media.AudioManager;
 import android.os.Bundle;
 import android.os.IBinder;
-import android.support.v4.content.ContextCompat;
+import androidx.core.content.ContextCompat;
 import android.util.Log;
 import android.widget.TextView;
 import android.widget.Toast;

--- a/app/src/main/java/de/rochefort/childmonitor/ListenService.java
+++ b/app/src/main/java/de/rochefort/childmonitor/ListenService.java
@@ -18,12 +18,14 @@ package de.rochefort.childmonitor;
 
 import static de.rochefort.childmonitor.AudioCodecDefines.CODEC;
 
+import android.annotation.SuppressLint;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Intent;
+import android.content.pm.ServiceInfo;
 import android.media.AudioManager;
 import android.media.AudioTrack;
 import android.media.MediaPlayer;
@@ -31,7 +33,9 @@ import android.os.Binder;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
-import android.support.v4.app.NotificationCompat;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.ServiceCompat;
+
 import android.util.Log;
 import android.widget.Toast;
 
@@ -76,7 +80,8 @@ public class ListenService extends Service {
             String name = extras.getString("name");
             childDeviceName = name;
             Notification n = buildNotification(name);
-            startForeground(ID, n);
+            final int foregroundServiceType =  (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) ? ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK : 0; // Keep the linter happy
+            ServiceCompat.startForeground(this, ID, n, foregroundServiceType);
             String address = extras.getString("address");
             int port = extras.getInt("port");
             doListen(address, port);
@@ -97,7 +102,7 @@ public class ListenService extends Service {
         int NOTIFICATION = R.string.listening;
         notificationManager.cancel(NOTIFICATION);
 
-        stopForeground(true);
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE);
         // Tell the user we stopped.
         Toast.makeText(this, R.string.stopped, Toast.LENGTH_SHORT).show();
     }

--- a/app/src/main/java/de/rochefort/childmonitor/MonitorActivity.java
+++ b/app/src/main/java/de/rochefort/childmonitor/MonitorActivity.java
@@ -27,7 +27,7 @@ import android.net.Network;
 import android.net.NetworkInfo;
 import android.os.Bundle;
 import android.os.IBinder;
-import android.support.v4.content.ContextCompat;
+import androidx.core.content.ContextCompat;
 import android.util.Log;
 import android.widget.TextView;
 import android.widget.Toast;

--- a/app/src/main/java/de/rochefort/childmonitor/MonitorService.java
+++ b/app/src/main/java/de/rochefort/childmonitor/MonitorService.java
@@ -24,6 +24,7 @@ import android.app.NotificationManager;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ServiceInfo;
 import android.media.AudioRecord;
 import android.media.MediaRecorder;
 import android.net.nsd.NsdManager;
@@ -31,10 +32,12 @@ import android.net.nsd.NsdServiceInfo;
 import android.os.Binder;
 import android.os.Build;
 import android.os.IBinder;
-import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.ServiceCompat;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -129,7 +132,8 @@ public class MonitorService extends Service {
         // Display a notification about us starting.  We put an icon in the status bar.
         createNotificationChannel();
         Notification n = buildNotification();
-        startForeground(ID, n);
+        final int foregroundServiceType =  (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) ? ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE : 0; // Keep the linter happy
+        ServiceCompat.startForeground(this, ID, n, foregroundServiceType);
         ensureMonitorThread();
 
         return START_REDELIVER_INTENT;
@@ -157,6 +161,7 @@ public class MonitorService extends Service {
 
                     // Wait for a parent to find us and connect
                     try (Socket socket = serverSocket.accept()) {
+
                         Log.i(TAG, "Connection from parent device received");
 
                         // We now have a client connection.
@@ -290,8 +295,7 @@ public class MonitorService extends Service {
         }
 
         // Cancel the persistent notification.
-        int NOTIFICATION = R.string.listening;
-        notificationManager.cancel(NOTIFICATION);
+        notificationManager.cancel(R.string.listening);
 
         stopForeground(true);
         // Tell the user we stopped.

--- a/app/src/main/java/de/rochefort/childmonitor/StartActivity.java
+++ b/app/src/main/java/de/rochefort/childmonitor/StartActivity.java
@@ -21,8 +21,8 @@ import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.ContextCompat;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 import android.util.Log;
 import android.widget.Button;
 

--- a/app/src/main/java/de/rochefort/childmonitor/VolumeHistory.java
+++ b/app/src/main/java/de/rochefort/childmonitor/VolumeHistory.java
@@ -18,7 +18,7 @@ package de.rochefort.childmonitor;
 
 import android.os.Handler;
 import android.os.Looper;
-import android.support.v4.util.CircularArray;
+import androidx.collection.CircularArray;
 
 public class VolumeHistory {
     private double maxVolume = 0.25;

--- a/app/src/main/java/de/rochefort/childmonitor/VolumeView.java
+++ b/app/src/main/java/de/rochefort/childmonitor/VolumeView.java
@@ -20,7 +20,7 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import android.util.AttributeSet;
 import android.view.View;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,8 @@
 # The aapt2 tool creates an APK which fails to install on Android 5 and below if it contains
 # a bug. Build tools 27.0.1 has a mitigation. Avoiding aapt2 also avoids hitting the bug.
 # See: https://issuetracker.google.com/issues/64434571
+android.enableJetifier=false
 android.nonFinalResIds=false
 android.nonTransitiveRClass=true
+android.useAndroidX=true
 org.gradle.configuration-cache=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Tue Apr 14 20:27:54 CEST 2020
+#Sun Feb 18 21:28:01 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=9631d53cf3e74bfa726893aee1f8994fee4e060c401335946dba2156f440f24c
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
-distributionSha256Sum=7c3ad722e9b0ce8205b91560fd6ce8296ac3eadf065672242fd73c06b8eeb6ee


### PR DESCRIPTION
I am not sure, if that is even in your interest. Hence an RFC.

As I read it from documentation and from suggestions from Android Studio, that the code base is following rather old patterns.

My understanding is, the best practice is `compileSDK=targetSdkVersion` and latest API release and use backward compatible classes or function wrappers to support `minSdkVersion`.

At last on a simulator, the code was still running on an Android Lollipop 5.1.

- Update gradle to the latest and greatest. I was in the wrong assumption that gradle needs to match the android plugin version. But it needs to be actually the same or higher version.
- Android X splits off the libraries that are provided with the dex file into the androidx namspace.
- desugar_jdk_libs_nio allows you to use post java 1.8 features, while still running on a 1.8 JVM. Not used yet, so a bit of waste, but hey.

And it looks like the doing UI things in the onStart function is not a good pattern.
See:  https://developer.android.com/topic/libraries/architecture/lifecycle
