### PR TITLE
Normalize volume for brightness

### DIFF
--- a/app/src/main/kotlin/de/rochefort/childmonitor/VolumeView.kt
+++ b/app/src/main/kotlin/de/rochefort/childmonitor/VolumeView.kt
@@ -52,10 +52,11 @@ class VolumeView : View {
         val width = width
         val size = volumeHistory.size() // Size is at most width
         val volumeNorm = volumeHistory.volumeNorm
+        val minBrightness = 0.3
         val relativeBrightness: Double = if (size > 0) {
-            volumeHistory[size - 1].coerceAtLeast(0.3)
+            (volumeNorm * volumeHistory[size - 1]).coerceAtLeast(minBrightness)
         } else {
-            0.3
+            minBrightness
         }
         val blue: Int
         val rest: Int


### PR DESCRIPTION
Undo an unintentional change done in f6a429e.
The brightness was calculated from the normalized volume, but when factoring the norm out in the history, that norm was dropped.