### PR TITLE
Remove setters, and rename callbacks for onSomething

### DIFF
--- a/app/src/main/kotlin/de/rochefort/childmonitor/ListenActivity.kt
+++ b/app/src/main/kotlin/de/rochefort/childmonitor/ListenActivity.kt
@@ -48,8 +48,8 @@ class ListenActivity : Activity() {
             connectedText.text = bs.childDeviceName
             val volumeView = findViewById<VolumeView>(R.id.volume)
             volumeView.volumeHistory = bs.volumeHistory
-            bs.setUpdateCallback { volumeView.postInvalidate() }
-            bs.setErrorCallback { postErrorMessage() }
+            bs.onUpdate = { volumeView.postInvalidate() }
+            bs.onError = { postErrorMessage() }
         }
 
         override fun onServiceDisconnected(className: ComponentName) {

--- a/app/src/main/kotlin/de/rochefort/childmonitor/ListenService.kt
+++ b/app/src/main/kotlin/de/rochefort/childmonitor/ListenService.kt
@@ -116,21 +116,13 @@ class ListenService : Service() {
         }
     }
 
-    fun setErrorCallback(errorCallback: (() -> Unit)) {
-        this.errorCallback = errorCallback
-    }
-
-    fun setUpdateCallback(updateCallback: (() -> Unit)) {
-        this.updateCallback = updateCallback
-    }
-
     inner class ListenBinder : Binder() {
         val service: ListenService
             get() = this@ListenService
     }
 
-    private var errorCallback: (() -> Unit)? = null
-    private var updateCallback: (() -> Unit)? = null
+    var onError: (() -> Unit)? = null
+    var onUpdate: (() -> Unit)? = null
     private fun doListen(address: String?, port: Int) {
         val lt = Thread {
             try {
@@ -139,7 +131,7 @@ class ListenService : Service() {
                 val success = streamAudio(socket)
                 if (!success) {
                     playAlert()
-                    errorCallback?.invoke()
+                    onError?.invoke()
                 }
             } catch (e : IOException) {
                 Log.e(TAG, "Error opening socket to $address on port $port", e)
@@ -186,7 +178,7 @@ class ListenService : Service() {
                     val decodedBytes = ShortArray(decoded)
                     System.arraycopy(decodedBuffer, 0, decodedBytes, 0, decoded)
                     volumeHistory.onAudioData(decodedBytes)
-                    updateCallback?.invoke()
+                    onUpdate?.invoke()
                 }
             }
             return true

--- a/app/src/main/kotlin/de/rochefort/childmonitor/MonitorActivity.kt
+++ b/app/src/main/kotlin/de/rochefort/childmonitor/MonitorActivity.kt
@@ -39,7 +39,7 @@ class MonitorActivity : Activity() {
             // service that we know is running in our own process, we can
             // cast its IBinder to a concrete class and directly access it.
             val bs = (service as MonitorBinder).service
-            bs.setMonitorActivity(this@MonitorActivity)
+            bs.monitorActivity = this@MonitorActivity
         }
 
         override fun onServiceDisconnected(className: ComponentName) {

--- a/app/src/main/kotlin/de/rochefort/childmonitor/MonitorService.kt
+++ b/app/src/main/kotlin/de/rochefort/childmonitor/MonitorService.kt
@@ -48,10 +48,7 @@ class MonitorService : Service() {
     private var currentPort = 0
     private lateinit var notificationManager: NotificationManager
     private var monitorThread: Thread? = null
-    private var monitorActivity: MonitorActivity? = null
-    fun setMonitorActivity(monitorActivity: MonitorActivity?) {
-        this.monitorActivity = monitorActivity
-    }
+    var monitorActivity: MonitorActivity? = null
 
     private fun serviceConnection(socket: Socket) {
         val ma = this.monitorActivity


### PR DESCRIPTION
- Setters are rather java-esque, and ...
- callbacks in the Android ecosystem are usually more called on&lt;EventName&gt; than &lt;EventName&gt;Callback.