### PR TITLE
Remove setting sendBufferSize as it doesn't work.

### DIFF
--- a/app/src/main/kotlin/de/rochefort/childmonitor/MonitorService.kt
+++ b/app/src/main/kotlin/de/rochefort/childmonitor/MonitorService.kt
@@ -78,8 +78,6 @@ class MonitorService : Service() {
         try {
             audioRecord.startRecording()
             val out = socket.getOutputStream()
-            socket.sendBufferSize = pcmBufferSize
-            Log.d(TAG, "Socket send buffer size: " + socket.sendBufferSize)
             while (socket.isConnected && (this.currentSocket != null) && !Thread.currentThread().isInterrupted) {
                 val read = audioRecord.read(pcmBuffer, 0, bufferSize)
                 val encoded: Int = AudioCodecDefines.CODEC.encode(pcmBuffer, read, ulawBuffer, 0)


### PR DESCRIPTION
The buffer size cannot be changed on a connected socket. It needs to be either set before
 `connect` (for the client), or before calling `listen` on the server socket.

> On individual connections, the socket buffer size must be set prior
> to the listen(2) or connect(2) calls in order to have it take effect

Unfortunately, setting the sendBufferSize on the ServerSocket is not
supported  under Java, so we only left to remove that statement.