### PR TITLE
Add pairing PIN authentication before audio stream

### DIFF
--- a/app/src/main/kotlin/de/rochefort/childmonitor/DiscoverActivity.kt
+++ b/app/src/main/kotlin/de/rochefort/childmonitor/DiscoverActivity.kt
@@ -57,6 +57,7 @@ class DiscoverActivity : Activity() {
         val connectButton = findViewById<Button>(R.id.connectViaAddressButton)
         val addressField = findViewById<EditText>(R.id.ipAddressField)
         val portField = findViewById<EditText>(R.id.portField)
+        val pinField = findViewById<EditText>(R.id.pinField)
         val preferredAddress = getPreferences(MODE_PRIVATE).getString(PREF_KEY_CHILD_DEVICE_ADDRESS, null)
         if (!preferredAddress.isNullOrEmpty()) {
             addressField.setText(preferredAddress)
@@ -81,11 +82,12 @@ class DiscoverActivity : Activity() {
                 Toast.makeText(this@DiscoverActivity, R.string.invalidPort, Toast.LENGTH_LONG).show()
                 return@setOnClickListener
             }
+            val pairingPin = readPairingPin(pinField) ?: return@setOnClickListener
             val preferencesEditor = getPreferences(MODE_PRIVATE).edit()
             preferencesEditor.putString(PREF_KEY_CHILD_DEVICE_ADDRESS, addressString)
             preferencesEditor.putInt(PREF_KEY_CHILD_DEVICE_PORT, port)
             preferencesEditor.apply()
-            connectToChild(addressString, port, addressString)
+            connectToChild(addressString, port, addressString, pairingPin)
         }
     }
 
@@ -113,13 +115,17 @@ class DiscoverActivity : Activity() {
             }
         }
         val serviceTable = findViewById<ListView>(R.id.ServiceTable)
+        val pinField = findViewById<EditText>(R.id.pinField)
         val availableServicesAdapter = ArrayAdapter<ServiceInfoWrapper>(this,
                 R.layout.available_children_list)
         serviceTable.adapter = availableServicesAdapter
         serviceTable.onItemClickListener = OnItemClickListener { parent: AdapterView<*>, _: View?, position: Int, _: Long ->
             val info = parent.getItemAtPosition(position) as ServiceInfoWrapper
-            info.address?.let {
-                connectToChild(it, info.port, info.name)
+            val pairingPin = readPairingPin(pinField)
+            if (pairingPin != null) {
+                info.address?.let {
+                    connectToChild(it, info.port, info.name, pairingPin)
+                }
             }
         }
 
@@ -158,7 +164,7 @@ class DiscoverActivity : Activity() {
                             }
                         }
                     }
-                    this@DiscoverActivity.nsdManager.resolveService(service, resolver)
+                    nsdManager.resolveService(service, resolver)
                 } else {
                     Log.d(TAG, "Unknown Service name: " + service.serviceName)
                 }
@@ -193,12 +199,22 @@ class DiscoverActivity : Activity() {
         )
     }
 
-    private fun connectToChild(address: String, port: Int, name: String) {
+    private fun readPairingPin(pinField: EditText): String? {
+        val pairingPin = pinField.text.toString().trim()
+        if (!PAIRING_PIN_PATTERN.matches(pairingPin)) {
+            Toast.makeText(this@DiscoverActivity, R.string.invalidPairingPin, Toast.LENGTH_LONG).show()
+            return null
+        }
+        return pairingPin
+    }
+
+    private fun connectToChild(address: String, port: Int, name: String, pairingPin: String) {
         val i = Intent(applicationContext, ListenActivity::class.java)
         val b = Bundle()
         b.putString("address", address)
         b.putInt("port", port)
         b.putString("name", name)
+        b.putString("pairingPin", pairingPin)
         i.putExtras(b)
         startActivity(i)
     }
@@ -207,6 +223,7 @@ class DiscoverActivity : Activity() {
         private const val TAG = "ChildMonitor"
         private const val PREF_KEY_CHILD_DEVICE_ADDRESS = "childDeviceAddress"
         private const val PREF_KEY_CHILD_DEVICE_PORT = "childDevicePort"
+        private val PAIRING_PIN_PATTERN = Regex("\\d{6}")
     }
 }
 

--- a/app/src/main/kotlin/de/rochefort/childmonitor/ListenActivity.kt
+++ b/app/src/main/kotlin/de/rochefort/childmonitor/ListenActivity.kt
@@ -69,6 +69,7 @@ class ListenActivity : Activity() {
             intent.putExtra("name", it.getString("name"))
             intent.putExtra("address", it.getString("address"))
             intent.putExtra("port", it.getInt("port"))
+            intent.putExtra("pairingPin", it.getString("pairingPin"))
             ContextCompat.startForegroundService(context, intent)
         }
         // Attempts to establish a connection with the service.  We use an

--- a/app/src/main/kotlin/de/rochefort/childmonitor/ListenService.kt
+++ b/app/src/main/kotlin/de/rochefort/childmonitor/ListenService.kt
@@ -66,7 +66,8 @@ class ListenService : Service() {
             ServiceCompat.startForeground(this, ID, n, foregroundServiceType)
             val address = it.getString("address")
             val port = it.getInt("port")
-            doListen(address, port)
+            val pairingPin = it.getString("pairingPin")
+            doListen(address, port, pairingPin)
         }
         return START_REDELIVER_INTENT
     }
@@ -123,11 +124,12 @@ class ListenService : Service() {
 
     var onError: (() -> Unit)? = null
     var onUpdate: (() -> Unit)? = null
-    private fun doListen(address: String?, port: Int) {
+    private fun doListen(address: String?, port: Int, pairingPin: String?) {
         val lt = Thread {
             try {
                 val socket = Socket(address, port)
                 socket.soTimeout = 30_000
+                sendPairingPin(socket, pairingPin)
                 val success = streamAudio(socket)
                 if (!success) {
                     playAlert()
@@ -135,10 +137,21 @@ class ListenService : Service() {
                 }
             } catch (e : IOException) {
                 Log.e(TAG, "Error opening socket to $address on port $port", e)
+                playAlert()
+                onError?.invoke()
             }
         }
         this.listenThread = lt
         lt.start()
+    }
+
+    private fun sendPairingPin(socket: Socket, pairingPin: String?) {
+        if (pairingPin.isNullOrBlank()) {
+            throw IOException("Missing pairing PIN")
+        }
+        val out = socket.getOutputStream()
+        out.write((pairingPin.trim() + "\n").toByteArray(Charsets.US_ASCII))
+        out.flush()
     }
 
     private fun streamAudio(socket: Socket): Boolean {

--- a/app/src/main/kotlin/de/rochefort/childmonitor/MonitorActivity.kt
+++ b/app/src/main/kotlin/de/rochefort/childmonitor/MonitorActivity.kt
@@ -40,6 +40,7 @@ class MonitorActivity : Activity() {
             // cast its IBinder to a concrete class and directly access it.
             val bs = (service as MonitorBinder).service
             bs.monitorActivity = this@MonitorActivity
+            bs.updateMonitorActivity()
         }
 
         override fun onServiceDisconnected(className: ComponentName) {

--- a/app/src/main/kotlin/de/rochefort/childmonitor/MonitorService.kt
+++ b/app/src/main/kotlin/de/rochefort/childmonitor/MonitorService.kt
@@ -38,6 +38,8 @@ import androidx.core.app.ServiceCompat
 import java.io.IOException
 import java.net.ServerSocket
 import java.net.Socket
+import java.security.SecureRandom
+import java.util.Locale
 
 class MonitorService : Service() {
     private val binder: IBinder = MonitorBinder()
@@ -48,7 +50,37 @@ class MonitorService : Service() {
     private var currentPort = 0
     private lateinit var notificationManager: NotificationManager
     private var monitorThread: Thread? = null
+    private lateinit var pairingPin: String
     var monitorActivity: MonitorActivity? = null
+
+    fun updateMonitorActivity() {
+        val ma = this.monitorActivity ?: return
+        ma.runOnUiThread {
+            val pairingPinText = ma.findViewById<TextView>(R.id.pairingPin)
+            pairingPinText.text = pairingPin
+        }
+    }
+
+    private fun authenticateParent(socket: Socket): Boolean {
+        return try {
+            socket.soTimeout = AUTH_TIMEOUT_MS
+            val providedPin = socket.getInputStream().bufferedReader(Charsets.US_ASCII).readLine()?.trim()
+            val authenticated = providedPin == pairingPin
+            if (!authenticated) {
+                Log.w(TAG, "Rejected parent connection with invalid pairing PIN")
+            }
+            authenticated
+        } catch (e: IOException) {
+            Log.w(TAG, "Failed to authenticate parent connection", e)
+            false
+        } finally {
+            try {
+                socket.soTimeout = 0
+            } catch (e: IOException) {
+                Log.d(TAG, "Failed to reset socket timeout after authentication", e)
+            }
+        }
+    }
 
     private fun serviceConnection(socket: Socket) {
         val ma = this.monitorActivity
@@ -99,6 +131,7 @@ class MonitorService : Service() {
         this.nsdManager = this.getSystemService(NSD_SERVICE) as NsdManager
         this.currentPort = 10000
         this.currentSocket = null
+        this.pairingPin = generatePairingPin()
     }
 
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
@@ -130,14 +163,21 @@ class MonitorService : Service() {
                         // Register the service so that parent devices can
                         // locate the child device
                         registerService(localPort)
-                        serverSocket.accept().use { socket ->
-                            Log.i(TAG, "Connection from parent device received")
+                        var authenticatedConnectionHandled = false
+                        while (!authenticatedConnectionHandled &&
+                                this.connectionToken == currentToken &&
+                                !Thread.currentThread().isInterrupted) {
+                            serverSocket.accept().use { socket ->
+                                Log.i(TAG, "Connection from parent device received")
 
-                            // We now have a client connection.
-                            // Unregister so no other clients will
-                            // attempt to connect
-                            unregisterService()
-                            serviceConnection(socket)
+                                if (authenticateParent(socket)) {
+                                    // We now have an authenticated client connection.
+                                    // Unregister so no other clients will attempt to connect.
+                                    unregisterService()
+                                    serviceConnection(socket)
+                                    authenticatedConnectionHandled = true
+                                }
+                            }
                         }
                     }
                 } catch (e: Exception) {
@@ -173,6 +213,8 @@ class MonitorService : Service() {
                             serviceText.text = serviceName
                             val portText = ma.findViewById<TextView>(R.id.port)
                             portText.text = port.toString()
+                            val pairingPinText = ma.findViewById<TextView>(R.id.pairingPin)
+                            pairingPinText.text = pairingPin
                         }
                     }
                 }
@@ -265,5 +307,11 @@ class MonitorService : Service() {
         const val TAG = "MonitorService"
         const val CHANNEL_ID = TAG
         const val ID = 1338
+        private const val AUTH_TIMEOUT_MS = 10_000
+        private val PIN_RANDOM = SecureRandom()
+
+        private fun generatePairingPin(): String {
+            return String.format(Locale.US, "%06d", PIN_RANDOM.nextInt(1_000_000))
+        }
     }
 }

--- a/app/src/main/res/layout/activity_discover_address.xml
+++ b/app/src/main/res/layout/activity_discover_address.xml
@@ -36,6 +36,7 @@
         android:id="@+id/ipAddressTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:labelFor="@id/ipAddressField"
         android:textSize="20sp"
         android:text="@string/addressTitle" />
 
@@ -55,6 +56,7 @@
         android:id="@+id/portTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:labelFor="@id/portField"
         android:textSize="20sp"
         android:text="@string/portTitle" />
 
@@ -67,7 +69,26 @@
         android:inputType="number"
         android:maxLength="5"
         android:hint="@string/examplePort"
-        android:nextFocusForward="@+id/connectViaAddressButton"/>
+        android:nextFocusForward="@+id/pinField"/>
+
+    <TextView
+        android:id="@+id/pairingPinTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:labelFor="@id/pinField"
+        android:textSize="20sp"
+        android:text="@string/pairingPinTitle" />
+
+    <EditText
+        android:id="@+id/pinField"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:hint="@string/examplePairingPin"
+        android:inputType="numberPassword"
+        android:maxLength="6"
+        android:textSize="20sp"
+        android:nextFocusForward="@+id/connectViaAddressButton" />
 
     <Space
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_discover_mdns.xml
+++ b/app/src/main/res/layout/activity_discover_mdns.xml
@@ -29,6 +29,24 @@
         android:text="@string/selectChildDevice"
         android:textSize="20sp" />
 
+    <TextView
+        android:id="@+id/pairingPinTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:labelFor="@id/pinField"
+        android:text="@string/pairingPinTitle"
+        android:textSize="20sp" />
+
+    <EditText
+        android:id="@+id/pinField"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:hint="@string/examplePairingPin"
+        android:inputType="numberPassword"
+        android:maxLength="6"
+        android:textSize="20sp" />
+
     <ListView
         android:id="@+id/ServiceTable"
         android:scrollbars="vertical"

--- a/app/src/main/res/layout/activity_monitor.xml
+++ b/app/src/main/res/layout/activity_monitor.xml
@@ -60,6 +60,26 @@
                 android:layout_width="match_parent"
                 android:layout_height="15dip" />
 
+            <TextView
+                android:id="@+id/pairingPinTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/pairingPinTitle"
+                android:textSize="20sp" />
+
+            <TextView
+                android:id="@+id/pairingPin"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/loading"
+                android:textSize="20sp" />
+
+            <TextView
+                android:id="@+id/pairingPinDescription"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/pairingPinDescription" />
+
             <Space
                 android:layout_width="match_parent"
                 android:layout_height="15dip" />

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -10,6 +10,8 @@
     <string name="childDevice">Kind-Gerät</string>
     <string name="serviceTitle">Dienst:</string>
     <string name="serviceDescription">Name des Diensten, mit dem sich die Eltern verbinden müssen.</string>
+    <string name="pairingPinTitle">Kopplungs-PIN:</string>
+    <string name="pairingPinDescription">Gib diese PIN vor dem Verbinden auf dem Eltern-Gerät ein.</string>
     <string name="loading">Lade...</string>
     <string name="stopped">Angehalten</string>
     <string name="streaming">Streaming...</string>
@@ -27,8 +29,10 @@
     <string name="connect">Verbinden</string>
     <string name="exampleAddress">192.168.1.2</string>
     <string name="examplePort">10000</string>
+    <string name="examplePairingPin">123456</string>
     <string name="invalidPort">Entweder wurde kein Port eingegeben oder er ist ungültig</string>
     <string name="invalidAddress">Das Adressfeld muss ausgefüllt sein</string>
+    <string name="invalidPairingPin">Gib die 6-stellige Kopplungs-PIN vom Kind-Gerät ein</string>
     <string name="discoverChild">Suche Kind im Netzwerk</string>
     <string name="discoverChildDescription">Wähle ein Kind aus einer Liste der erkannten Kinder im Netzwerk</string>
     <string name="enterChildAddress">Wähle Kind durch Adresse</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,8 @@
     <string name="childDevice">Child Device</string>
     <string name="serviceTitle">Service:</string>
     <string name="serviceDescription">Name of the service that parent must pair to</string>
+    <string name="pairingPinTitle">Pairing PIN:</string>
+    <string name="pairingPinDescription">Enter this PIN on the parent device before connecting.</string>
     <string name="loading">Loading...</string>
     <string name="stopped">Stopped</string>
     <string name="streaming">Streaming...</string>
@@ -27,8 +29,10 @@
     <string name="connect">Connect</string>
     <string name="exampleAddress">192.168.1.2</string>
     <string name="examplePort">10000</string>
+    <string name="examplePairingPin">123456</string>
     <string name="invalidPort">Either no port was entered or it is invalid</string>
     <string name="invalidAddress">The address field needs to be filled out</string>
+    <string name="invalidPairingPin">Enter the 6-digit pairing PIN shown on the child device</string>
     <string name="discoverChild">Discover Child on Network</string>
     <string name="discoverChildDescription">Select child from a list of discovered children on the network</string>
     <string name="enterChildAddress">Select Child by Address</string>


### PR DESCRIPTION
## Summary

Adds a 6-digit pairing PIN authentication layer before audio streaming begins. The child device generates and displays a random PIN, and the parent device must enter it before connecting.

## Changes

### Child device (MonitorService)
- Generates a 6-digit PIN when `MonitorService` is created, using `SecureRandom`
- Displays the PIN in the child device UI (`activity_monitor.xml`)
- Validates the PIN before accepting a parent connection
- Rejects connections with an invalid or missing PIN before audio streaming starts

### Parent device (DiscoverActivity, ListenService)
- Adds a PIN input field to the mDNS discovery flow (`activity_discover_mdns.xml`)
- Adds a PIN input field to the manual address entry flow (`activity_discover_address.xml`)
- Validates the PIN format as exactly 6 digits
- Sends the PIN to the child device before reading the audio stream

### UI updates
- Adds PIN display on the child device screen
- Adds PIN input fields on both parent discovery screens
- Adds English and German strings for the new PIN UI

## Security considerations

This is the first security layer: authentication only, not encryption.

- It prevents casual unauthorized connections from devices on the same network that do not know the displayed PIN.
- The PIN and audio stream are still transmitted in plaintext.
- A new random PIN is generated for each `MonitorService` lifetime.
- Transport encryption should be handled in a follow-up change.

## Relationship to #33

This PR is intended to be reviewed after #33. It currently includes the same `DiscoverActivity.kt` resolver build fix because it is based on `master`, where #33 has not been merged yet. If #33 is merged first, this branch should be rebased to remove that overlap.

## Verification

Run locally with JDK 21 and Android SDK 34 installed:

```bash
./gradlew assembleRelease testReleaseUnitTest lintRelease
```

Result: `BUILD SUCCESSFUL`.

Note: this branch does not include the CI workflow and Java 17 bytecode configuration from #33, so local lint still logs class-file compatibility messages. Those are addressed by #33.

Signed-off-by: digitalesIch <digitalesich@gmail.com>
